### PR TITLE
Fix not_loaded error

### DIFF
--- a/apps/erlang_notebook_nif/src/erlang_notebook_nif.erl
+++ b/apps/erlang_notebook_nif/src/erlang_notebook_nif.erl
@@ -25,4 +25,4 @@ init() ->
     erlang:load_nif(SoName, 0).
 
 not_loaded(Line) ->
-    exit({not_loaded, [{module, ?MODULE}, {line, Line}]}).
+    erlang:nif_error({not_loaded, [{module, ?MODULE}, {line, Line}]}).


### PR DESCRIPTION
exit will make dialyzer complain, erlang:nif_error/1 should be used instead.

http://erlang.org/documentation/doc-5.8/erts-5.8/doc/html/erlang.html#nif_error-1
